### PR TITLE
Bug fixes.

### DIFF
--- a/eccles/src/main/java/au/edu/uq/cmm/eccles/EcclesProxyConfiguration.java
+++ b/eccles/src/main/java/au/edu/uq/cmm/eccles/EcclesProxyConfiguration.java
@@ -6,12 +6,14 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.persistence.CollectionTable;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 
@@ -127,7 +129,8 @@ public class EcclesProxyConfiguration implements ACLSProxyConfiguration {
         this.allowUnknownClients = allowUnknownClients;
     }
     
-    @ElementCollection(fetch=FetchType.EAGER, targetClass=HashSet.class)
+    @CollectionTable(name="trusted_addresses",joinColumns=@JoinColumn(name="addr_id"))
+    @ElementCollection()
     public Set<String> getTrustedAddresses() {
         return trustedAddresses;
     }

--- a/paul/src/main/java/au/edu/uq/cmm/paul/PaulConfiguration.java
+++ b/paul/src/main/java/au/edu/uq/cmm/paul/PaulConfiguration.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.persistence.CollectionTable;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EntityManager;
@@ -13,6 +14,7 @@ import javax.persistence.EntityManagerFactory;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.NoResultException;
 import javax.persistence.Table;
 import javax.persistence.Transient;
@@ -284,7 +286,8 @@ public class PaulConfiguration implements GrabberConfiguration {
         this.allowUnknownClients = allowUnknownClients;
     }
 
-    @ElementCollection(fetch=FetchType.EAGER, targetClass=HashSet.class)
+    @CollectionTable(name="trusted_addresses",joinColumns=@JoinColumn(name="addr_id"))
+    @ElementCollection()
     public Set<String> getTrustedAddresses() {
         return trustedAddresses;
     }

--- a/paul/src/main/java/au/edu/uq/cmm/paul/grabber/DatafileMetadata.java
+++ b/paul/src/main/java/au/edu/uq/cmm/paul/grabber/DatafileMetadata.java
@@ -25,6 +25,7 @@ import org.hibernate.annotations.GenericGenerator;
         uniqueConstraints=@UniqueConstraint(columnNames={"capturedFilePathname"}))
 public class DatafileMetadata {
     private String sourceFilePathname;
+    private String facilityFilePathname;
     private Date captureTimestamp;
     private Date fileWriteTimestamp;
     private String capturedFilePathname;
@@ -36,11 +37,13 @@ public class DatafileMetadata {
         super();
     }
     
-    public DatafileMetadata(String sourceFilePathname, String capturedFilePathname, 
-            Date captureTimestamp, Date fileWriteTimestamp, String mimeType,
-            long fileSize) {
+    public DatafileMetadata(
+            String sourceFilePathname, String facilityFilePathname,
+            String capturedFilePathname, Date captureTimestamp, 
+            Date fileWriteTimestamp, String mimeType, long fileSize) {
         super();
         this.sourceFilePathname = sourceFilePathname;
+        this.facilityFilePathname = facilityFilePathname;
         this.capturedFilePathname = capturedFilePathname;
         this.captureTimestamp = captureTimestamp;
         this.fileWriteTimestamp = fileWriteTimestamp;
@@ -76,6 +79,14 @@ public class DatafileMetadata {
 
     public void setSourceFilePathname(String sourceFilePathname) {
         this.sourceFilePathname = sourceFilePathname;
+    }
+
+    public String getFacilityFilePathname() {
+        return facilityFilePathname;
+    }
+
+    public void setFacilityFilePathname(String facilityFilePathname) {
+        this.facilityFilePathname = facilityFilePathname;
     }
 
     public void setCaptureTimestamp(Date captureTimestamp) {

--- a/paul/src/main/java/au/edu/uq/cmm/paul/grabber/DatasetMetadata.java
+++ b/paul/src/main/java/au/edu/uq/cmm/paul/grabber/DatasetMetadata.java
@@ -35,6 +35,7 @@ public class DatasetMetadata {
     private String facilityName;
     private String accountName;
     private String sourceFilePathnameBase;
+    private String facilityFilePathnameBase;
     private Date captureTimestamp;
     private Date updateTimestamp;
     private Date sessionStartTimestamp;
@@ -51,6 +52,7 @@ public class DatasetMetadata {
     }
     
     public DatasetMetadata(String sourceFilePathnameBase, 
+            String facilityFilePathnameBase,
             String metadataFilePathname, String userName, 
             String facilityName, Long facilityId,
             String accountName, String emailAddress, Date captureTimestamp,
@@ -58,6 +60,7 @@ public class DatasetMetadata {
             List<DatafileMetadata> datafiles) {
         super();
         this.sourceFilePathnameBase = sourceFilePathnameBase;
+        this.facilityFilePathnameBase = facilityFilePathnameBase;
         this.metadataFilePathname = metadataFilePathname;
         this.userName = userName;
         this.facilityName = facilityName;
@@ -163,6 +166,14 @@ public class DatasetMetadata {
 
     public void setSourceFilePathnameBase(String sourceFilePathnameBase) {
         this.sourceFilePathnameBase = sourceFilePathnameBase;
+    }
+
+    public String getFacilityFilePathnameBase() {
+        return facilityFilePathnameBase;
+    }
+
+    public void setFacilityFilePathnameBase(String facilityFilePathnameBase) {
+        this.facilityFilePathnameBase = facilityFilePathnameBase;
     }
 
     @OneToMany(cascade=CascadeType.ALL, fetch=FetchType.EAGER)

--- a/paul/src/main/java/au/edu/uq/cmm/paul/grabber/FileGrabber.java
+++ b/paul/src/main/java/au/edu/uq/cmm/paul/grabber/FileGrabber.java
@@ -138,7 +138,7 @@ public class FileGrabber extends CompositeServiceBase
         } finally {
             em.close();
         }
-        LOG.error("determineCatchupTime(" + facility.getFacilityName() + ") -> " + res);
+        LOG.info("determineCatchupTime(" + facility.getFacilityName() + ") -> " + res);
         return res;
     }
 

--- a/paul/src/main/java/au/edu/uq/cmm/paul/queue/QueueFeedAdapter.java
+++ b/paul/src/main/java/au/edu/uq/cmm/paul/queue/QueueFeedAdapter.java
@@ -138,7 +138,7 @@ public class QueueFeedAdapter extends AbstractEntityCollectionAdapter<DatasetMet
 
     @Override
     public String getTitle(DatasetMetadata record) throws ResponseContextException {
-        return record.getSourceFilePathnameBase();
+        return record.getFacilityFilePathnameBase();
     }
 
     @Override
@@ -186,7 +186,7 @@ public class QueueFeedAdapter extends AbstractEntityCollectionAdapter<DatasetMet
             entry.addLink(config.getBaseFileUrl() + 
                     new File(datafile.getCapturedFilePathname()).getName(),
                     "enclosure", datafile.getMimeType(), 
-                    datafile.getSourceFilePathname(),
+                    datafile.getFacilityFilePathname(),
                     "en", datafile.getFileSize());
         }
         entry.addLink(config.getBaseFileUrl() + 

--- a/paul/src/main/java/au/edu/uq/cmm/paul/status/FacilityStatusManager.java
+++ b/paul/src/main/java/au/edu/uq/cmm/paul/status/FacilityStatusManager.java
@@ -91,7 +91,7 @@ public class FacilityStatusManager {
             TypedQuery<FacilitySession> query = em.createQuery(
                     "from FacilitySession s where s.facilityName = :facilityName " +
                     "and s.loginTime <= :timestamp " +
-                    "and (s.logoutTime is null or s.logoutTime >= :timestamp " +
+                    "and (s.logoutTime is null or s.logoutTime >= :timestamp) " +
                     "order by s.loginTime desc", FacilitySession.class);
             query.setParameter("facilityName", facilityName);
             query.setParameter("timestamp", new Date(timestamp));

--- a/paul/src/main/webapp/WEB-INF/jsp/config.jsp
+++ b/paul/src/main/webapp/WEB-INF/jsp/config.jsp
@@ -17,6 +17,12 @@
 				${config.serverPort}</li>
 			<li>ACLS Proxy details:
 			    <ul>
+			   		<li>Allow unknown clients: ${config.allowUnknownClients}</li>
+			        <li>Trusted addresses: 
+			        	<c:forEach var="addr" items="${config.trustedAddresses}">
+			        		${addr} &nbsp;
+			        	</c:forEach>
+			        </li>
 			    	<li>Dummy facility name: ${config.dummyFacilityName}</li>
 			    	<li>Dummy facility hostId: ${config.dummyFacilityHostId}</li>
 			    </ul>

--- a/paul/src/main/webapp/WEB-INF/jsp/queueEntry.jsp
+++ b/paul/src/main/webapp/WEB-INF/jsp/queueEntry.jsp
@@ -34,11 +34,11 @@
 		<li>Session uuid: ${entry.sessionUuid}</li>
 		<li>Session start time: ${entry.sessionStartTimestamp}</li>
 		<li>Dataset uuid: ${entry.recordUuid}</li>
-		<li>Dataset base filename: ${entry.sourceFilePathnameBase}</li>
+		<li>Dataset base filename: ${entry.sourceFilePathnameBase} / ${entry.facilityFilePathnameBase}</li>
 		<li>Datafiles:
 			<ul>
 				<c:forEach items="${entry.datafiles}" var="datafile">
-					<li>Filename: ${datafile.sourceFilePathname}
+					<li>Filename: ${datafile.sourceFilePathname} / ${datafile.facilityFilePathname}
 						<ul>
 							<li>File id: ${datafile.id}</li>
 							<li>Captured filename: ${datafile.capturedFilePathname}</li>


### PR DESCRIPTION
Use the instrument pathnames as the "source" pathnames we send to Mirage.
Fixed file grabbing regression resulting from recent reorganizations.
Fixed persistence annotations for the (now) shared configuration table
