### PR TITLE
Fixes

### DIFF
--- a/paul/src/main/java/au/edu/uq/cmm/paul/grabber/PausableThreadPoolExecutor.java
+++ b/paul/src/main/java/au/edu/uq/cmm/paul/grabber/PausableThreadPoolExecutor.java
@@ -1,0 +1,54 @@
+/**
+ * This class is copied from the example in the ThreadPoolExecutor
+ * javadocs.
+ */
+package au.edu.uq.cmm.paul.grabber;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+class PausableThreadPoolExecutor extends ThreadPoolExecutor {
+    private boolean isPaused;
+    private ReentrantLock pauseLock = new ReentrantLock();
+    private Condition unpaused = pauseLock.newCondition();
+
+    public PausableThreadPoolExecutor(int corePoolSize, int maximumPoolSize,
+            long keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue);
+    }
+
+    protected void beforeExecute(Thread t, Runnable r) {
+        super.beforeExecute(t, r);
+        pauseLock.lock();
+        try {
+            while (isPaused)
+                unpaused.await();
+        } catch (InterruptedException ie) {
+            t.interrupt();
+        } finally {
+            pauseLock.unlock();
+        }
+    }
+
+    public void pause() {
+        pauseLock.lock();
+        try {
+            isPaused = true;
+        } finally {
+            pauseLock.unlock();
+        }
+    }
+
+    public void resume() {
+        pauseLock.lock();
+        try {
+            isPaused = false;
+            unpaused.signalAll();
+        } finally {
+            pauseLock.unlock();
+        }
+    }
+}

--- a/paul/src/main/java/au/edu/uq/cmm/paul/grabber/WorkEntry.java
+++ b/paul/src/main/java/au/edu/uq/cmm/paul/grabber/WorkEntry.java
@@ -73,6 +73,7 @@ class WorkEntry implements Runnable {
     private final Map<File, GrabbedFile> files;
     private final Facility facility;
     private final Date timestamp;
+    private long latestFileTimestamp = 0L;
     private final boolean holdDatasetsWithNoUser;
     private final boolean catchup;
     
@@ -94,7 +95,7 @@ class WorkEntry implements Runnable {
         this.catchup = event.isCatchup();
         addEvent(event);
     }
-
+    
     private String mapToInstrumentPath(Facility facility, File file) {
         String filePath = file.getAbsolutePath();
         FacilityStatus status = statusManager.getStatus(facility);
@@ -126,6 +127,7 @@ class WorkEntry implements Runnable {
             } else {
                 LOG.debug("File " + file + " already in map for grabbing");
             }
+            updateLatestFileTimestamp(file);
         } else {
             for (DatafileTemplate template : templates) {
                 Pattern pattern = template.getCompiledFilePattern(
@@ -139,6 +141,7 @@ class WorkEntry implements Runnable {
                     } else {
                         LOG.debug("File " + file + " already in map for grabbing");
                     }
+                    updateLatestFileTimestamp(file);
                     matched = true;
                     break;
                 }
@@ -147,6 +150,17 @@ class WorkEntry implements Runnable {
                 LOG.debug("File " + file + " didn't match any template - ignoring");
             }
         }
+    }
+
+    private void updateLatestFileTimestamp(File file) {
+        long timestamp = file.lastModified();
+        if (timestamp > latestFileTimestamp) {
+            latestFileTimestamp = timestamp;
+        }
+    }
+
+    public long getLatestFileTimestamp() {
+        return latestFileTimestamp;
     }
 
     @Override

--- a/paul/src/main/java/au/edu/uq/cmm/paul/queue/QueueFeedAdapter.java
+++ b/paul/src/main/java/au/edu/uq/cmm/paul/queue/QueueFeedAdapter.java
@@ -106,14 +106,14 @@ public class QueueFeedAdapter extends AbstractEntityCollectionAdapter<DatasetMet
                 query = entityManager.createQuery(
                         "from DatasetMetadata m where m.id <= :id " +
                         (holdDatasetsWithNoUser ? "and m.userName is not null " : "") +
-                        "order by m.updateTimestamp desc", 
+                        "order by m.updateTimestamp desc, m.id desc", 
                         DatasetMetadata.class).setParameter("id", id);
             } else {
                 LOG.debug("Fetching from start of queue");
                 query = entityManager.createQuery(
                         "from DatasetMetadata m " +
                         (holdDatasetsWithNoUser ? "where m.userName is not null " : "") +
-                        "order by m.updateTimestamp desc", 
+                        "order by m.updateTimestamp desc, m.id desc", 
                         DatasetMetadata.class);
             }
             query.setMaxResults(config.getFeedPageSize() + 1);

--- a/paul/src/main/java/au/edu/uq/cmm/paul/watcher/FileWatcher.java
+++ b/paul/src/main/java/au/edu/uq/cmm/paul/watcher/FileWatcher.java
@@ -164,7 +164,7 @@ public class FileWatcher extends MonitoredThreadServiceBase {
         FacilityStatus status = services.getFacilityStatusManager().getStatus(facility);
         FileGrabber grabber = status.getFileGrabber();
         if (grabber != null) {
-            grabber.eventOccurred(new FileWatcherEvent(facility, file, create, now));
+            grabber.eventOccurred(new FileWatcherEvent(facility, file, create, now, false));
         }
     }
 

--- a/paul/src/main/java/au/edu/uq/cmm/paul/watcher/FileWatcherEvent.java
+++ b/paul/src/main/java/au/edu/uq/cmm/paul/watcher/FileWatcherEvent.java
@@ -29,14 +29,17 @@ public class FileWatcherEvent extends EventObject {
     private final File file;
     private final boolean create;
     private final long timestamp;
+    private final boolean catchup;
     
-    public FileWatcherEvent(FacilityConfig facility, File file, boolean create, long timestamp) {
+    public FileWatcherEvent(FacilityConfig facility, File file, 
+            boolean create, long timestamp, boolean catchup) {
         super(facility);
         this.file = file;
         this.create = create;
         this.timestamp = timestamp;
+        this.catchup = catchup;
     }
-    
+
     public FacilityConfig getFacility() {
         return (FacilityConfig) getSource();
     }
@@ -51,5 +54,9 @@ public class FileWatcherEvent extends EventObject {
 
     public long getTimestamp() {
         return timestamp;
+    }
+
+    public boolean isCatchup() {
+        return catchup;
     }
 }


### PR DESCRIPTION
Major speedup for catchup mode.  It also needs to grab files in roughly the order of the original file timestamps.
The atom feed adapter needs to use a tie-breaker to get stable queue ordering when two entries have the same update timestamp.
